### PR TITLE
Complete initial specification

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -141,7 +141,7 @@
         <p>The implementation of HostImportModuleDynamically must conform to the following requirements:</p>
 
         <ul>
-          <li>`
+          <li>
             The abstract operation must always complete normally with *undefined*. Success or failure must instead be signaled as discussed below.
           </li>
           <li>
@@ -362,20 +362,20 @@
     <h1>Runtime Semantics: WithClauseToAttributes</h1>
     <emu-grammar>WithClause : `with` WithEntries</emu-grammar>
     <emu-alg>
-      1. Let _attributes_ WithEntriesToAttributes of |WithEntries|.
+      1. Let _attributes_ be WithEntriesToAttributes of |WithEntries|.
       1. Sort _attributes_ by the code point order of the [[Key]] of each entry.  NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among attributes by the order they occur in.
       1. Return _attributes_.
     </emu-alg>
 
     <emu-grammar> WithEntries : IdentifierName `:` StringLiteral </emu-grammar>
     <emu-alg>
-      1. Let _entry_ be a Record { [[Key]]: StringValue of |IdentifierName|, [[Value]]: StringValue of |StringLiteral|.
+      1. Let _entry_ be a Record { [[Key]]: StringValue of |IdentifierName|, [[Value]]: StringValue of |StringLiteral| }.
       1. Return a new List containing the single element, _entry_.
     </emu-alg>
 
     <emu-grammar> WithEntries : IdentifierName `:` StringLiteral `,` WithEntries </emu-grammar>
     <emu-alg>
-      1. Let _entry_ be a Record { [[Key]]: StringValue of |IdentifierName|, [[Value]]: StringValue of |StringLiteral|.
+      1. Let _entry_ be a Record { [[Key]]: StringValue of |IdentifierName|, [[Value]]: StringValue of |StringLiteral| }.
       1. Let _rest_ be WithEntriesToAttributes of |WithEntries|.
       1. Return a new List containing _entry_ followed by the entries of _rest_.
     </emu-alg>
@@ -564,7 +564,7 @@
         <emu-alg>
           1. <del>Return ModuleRequests of |FromClause|.</del>
           1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
-          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Attributes]]: an emptyList }.</ins>
+          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Attributes]]: an empty List }.</ins>
         </emu-alg>
         <emu-grammar>ImportDeclaration : `import` ImportClause FromClause WithClause `;`</emu-grammar>
         <emu-alg>
@@ -598,7 +598,7 @@
         <emu-alg>
           1. <del>Return ModuleRequests of |FromClause|.</del>
           1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
-          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Attributes]]: an emptyList }.</ins>
+          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Attributes]]: an empty List }.</ins>
         </emu-alg>
         <emu-grammar>
           ExportDeclaration : `export` ExportFromClause FromClause WithClause `;`

--- a/spec.html
+++ b/spec.html
@@ -25,13 +25,14 @@
       `import` ModuleSpecifier `;`
       <ins>`import` ImportClause FromClause WithClause `;`</ins>
       <ins>`import` ModuleSpecifier WithClause `;`</ins>
+      <ins>`export` ExportFromClause FromClause WithClause `;`</ins>
 
     WithClause :
-      <ins>`with` WithList</ins>
+      <ins>`with` WithEntries</ins>
 
-    WithList :
+    WithEntries :
       <ins>IdentifierName `:` StringLiteral</ins>
-      <ins>IdentifierName `:` StringLiteral `,` WithList</ins>
+      <ins>IdentifierName `:` StringLiteral `,` WithEntries</ins>
 
     ImportCall[Yield, Await] :
       `import` `(` AssignmentExpression[+In, ?Yield, ?Await] `,`? `)`
@@ -58,7 +59,8 @@
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
           1. Let _specifierString_ be ToString(_specifier_).
           1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
-          1. Perform ! HostImportModuleDynamically(_referencingScriptOrModule_, _specifierString_, <ins>*undefined*,</ins> _promiseCapability_).
+          1. <ins>Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Attributes]]: an empty List }.</ins>
+          1. Perform ! HostImportModuleDynamically(_referencingScriptOrModule_, <del>_specifierString_,</del> <ins>_moduleRequest_,</ins> _promiseCapability_).
           1. Return _promiseCapability_.[[Promise]].
         </emu-alg>
 
@@ -72,17 +74,27 @@
           1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
           1. <ins>Let _argRef_ be the result of evaluating the second |AssignmentExpression|.</ins>
           1. <ins>Let _arg_ be ? GetValue(_argRef_).</ins>
-          1. <ins>If _arg_ is *undefined*, let _attributes_ be *undefined*.</ins>
-          1. <ins>Otherwise, let _attributes_ be ? Get(_arg_, *"with"*).</ins>
-          1. Perform ! HostImportModuleDynamically(_referencingScriptOrModule_, _specifierString_, <ins>_attributes_,</ins> _promiseCapability_).
+          1. <ins>If _arg_ is *undefined*, let _attributes_ be an empty List.</ins>
+          1. <ins>Otherwise,</ins>
+            1. <ins>Let _attributesObj_ be ? Get(_arg_, *"with"*).</ins>
+            1. <ins>Let _attributes_ be a new empty List.</ins>
+            1. <ins>Let _keys_ be EnumerableOwnPropertyNames(_attributesObj_, ~key~).</ins>
+            1. <ins>IfAbruptRejectPromise(_keys_, _promiseCapability_).</ins>
+            1. <ins>For each String _key_ of _keys_,</ins>
+              1. <ins>Let _value_ be Get(_attributesObj_, _key_).</ins>
+              1. <ins>IfAbruptRejectPromise(_value_, _promiseCapability_).</ins>
+              1. <ins>Append { [[Key]]: _key_, [[Value]], _value_ } to _attributes_.</ins>
+            1. <ins>Sort _attributes_ by the code point order of the [[Key]] of each entry.  NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among attributes by the order they occur in.</ens>
+          1. <ins>Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Attributes]]: _attributes_ }.</ins>
+          1. Perform ! HostImportModuleDynamically(_referencingScriptOrModule_, <del>_specifierString_,</del> <ins>_moduleRequest_,</ins> _promiseCapability_).
           1. Return _promiseCapability_.[[Promise]].
         </emu-alg>
       </emu-clause>
     </emu-clause>
 
       <emu-clause id="sec-hostresolveimportedmodule" aoid="HostResolveImportedModule">
-        <h1>Runtime Semantics: HostResolveImportedModule ( _referencingScriptOrModule_, _specifier_<ins>, _attributes_</ins> )</h1>
-        <p>HostResolveImportedModule is an implementation-defined abstract operation that provides the concrete Module Record subclass instance that corresponds to the |ModuleSpecifier| String, _specifier_, occurring within the context of the script or module represented by the Script Record or Module Record _referencingScriptOrModule_. _referencingScriptOrModule_ may also be *null*, if the resolution is being performed in the context of an <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression, and there is no active script or module at that time. <ins>The _attributes_ parameter is an ECMAScript value representing the module attributes, originating either from an `import` statement or the second parameter of a dynamic `import()` expression. If no module attributes are provided, the value will be *undefined*.</ins></p>
+        <h1>Runtime Semantics: HostResolveImportedModule ( _referencingScriptOrModule_, <del>_specifier_</del> <ins>_moduleRequest_</ins> )</h1>
+        <p>HostResolveImportedModule is an implementation-defined abstract operation that provides the concrete Module Record subclass instance that corresponds to <del>the |ModuleSpecifier| String, _specifier_,</del><ins>the ModuleRequest Record _moduleRequest_</del> occurring within the context of the script or module represented by the Script Record or Module Record _referencingScriptOrModule_. _referencingScriptOrModule_ may also be *null*, if the resolution is being performed in the context of an <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression, and there is no active script or module at that time.</ins></p>
 
         <emu-note>
           <p>An example of when _referencingScriptOrModule_ can be *null* is in a web browser host. There, if a user clicks on a control given by</p>
@@ -98,36 +110,38 @@
             The normal return value must be an instance of a concrete subclass of Module Record.
           </li>
           <li>
-            If a Module Record corresponding to the <del>pair</del><ins>tuple</ins> _referencingScriptOrModule_, _specifier_<ins>, _attributes</ins> does not exist or cannot be created, an exception must be thrown.
+            If a Module Record corresponding to the pair _referencingScriptOrModule_, <del>_specifier_</del>, <ins>_moduleRequest_</ins> does not exist or cannot be created, an exception must be thrown.
           </li>
           <li>
-            Each time this operation is called with a specific _referencingScriptOrModule_, _specifier_<ins>, _attributes_</ins> <del>pair</del><ins>tuple</ins> as arguments it must return the same Module Record instance if it completes normally.
+            Each time this operation is called with a specific _referencingScriptOrModule_, <del>_specifier_,</del> <ins>_moduleRequest_</ins> pair as arguments it must return the same Module Record instance if it completes normally.
           </li>
           <li>
             <ins>
-              If _attributes_ is not *undefined*, then the implementation of HostResolveImportModule must perform <emu-alg>? Get(_attributes_, *"type"*)</emu-alg>. Let _type_ be the result. The following requirements apply:
+              If _attributes_ has an entry _entry_ such that _entry_.[[Key]] is *"type"*, let _type_ be _entry_.[[Value]]. The following requirements apply:
               <ul>
                 <li>If _type_ is *"json"*, then this algorithm must either invoke ParseJSONModule and return the resulting Module Record, or throw an exception.</li>
-                <li>Each time this operation is called with a specific _referencingScriptOrModule_, _specifier_, _otherAttributes_ tuple as arguments, <em>if _otherAttributes_ differs from _attributes_ only based on the value of _type_</em> it must return the same Module Record instance if it completes normally.</li>
+                <li>Each time this operation is called with a specific _referencingScriptOrModule_, _moduleRequest_ pair as arguments, <em>if _moduleRequest_.[[Attributes]] differs only based on _entry_,</em> it must return the same Module Record instance if it completes normally.</li>
               </ul>
             </ins>
           </li>
-          <li>
-            <ins></ins>
-          </li>
         </ul>
         <p>Multiple different _referencingScriptOrModule_, _specifier_ pairs may map to the same Module Record instance. The actual mapping semantic is implementation-defined but typically a normalization process is applied to _specifier_ as part of the mapping process. A typical normalization process would include actions such as alphabetic case folding and expansion of relative and abbreviated path specifiers.</p>
+
+        <emu-note type=editor>
+          <p>The above text implies that, if a module is imported multiple times with different _type_ values, then there can be just one possible "successful" value (possibly as a result of multiple different types), but that it can also fail with an exception thrown; this exception from one import does not rule out success with a different type.</p>
+          <p>The above text implies that hosts *must* support JSON modules imported with `type: "json"` (if it completes normally), but it doesn't prohibit hosts from supporting JSON modules imported with no type specified. Some environments (for example, web browsers) are expected to require `with type: "json"`, and environments which want to restrict themselves to a compatible subset would do so as well.</p>
+        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-hostimportmoduledynamically" aoid="HostImportModuleDynamically">
-        <h1>Runtime Semantics: HostImportModuleDynamically ( _referencingScriptOrModule_, _specifier_, <ins>_attributes_,</ins> _promiseCapability_ )</h1>
-        <p>HostImportModuleDynamically is an implementation-defined abstract operation that performs any necessary setup work in order to make available the module corresponding to the |ModuleSpecifier| String, _specifier_, occurring within the context of the script or module represented by the Script Record or Module Record _referencingScriptOrModule_, <ins>with module attributes _attributes</ins>. (_referencingScriptOrModule_ may also be *null*, if there is no active script or module when the <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression occurs.) It then performs FinishDynamicImport to finish the dynamic import process.</p>
+        <h1>Runtime Semantics: HostImportModuleDynamically ( _referencingScriptOrModule_, <del>_specifier_,<del> <ins>_moduleRequest_,</ins> _promiseCapability_ )</h1>
+        <p>HostImportModuleDynamically is an implementation-defined abstract operation that performs any necessary setup work in order to make available the module corresponding to the <del>|ModuleSpecifier| String, _specifier_,</del><ins>ModuleRequest Record _moduleRequest_</ins> occurring within the context of the script or module represented by the Script Record or Module Record _referencingScriptOrModule_. (_referencingScriptOrModule_ may also be *null*, if there is no active script or module when the <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression occurs.) It then performs FinishDynamicImport to finish the dynamic import process.</p>
 
 
         <p>The implementation of HostImportModuleDynamically must conform to the following requirements:</p>
 
         <ul>
-          <li>
+          <li>`
             The abstract operation must always complete normally with *undefined*. Success or failure must instead be signaled as discussed below.
           </li>
           <li>
@@ -137,11 +151,11 @@
 
               <dd>
                 <ul>
-                  <li>At some future time, the host environment must perform FinishDynamicImport(_referencingScriptOrModule_, _specifier_, <ins>_attributes_</ins>, _promiseCapability_, NormalCompletion(*undefined*)).</li>
+                  <li>At some future time, the host environment must perform FinishDynamicImport(_referencingScriptOrModule_, <del>_specifier_,</del> <ins>_moduleRequest_</ins>, _promiseCapability_, NormalCompletion(*undefined*)).</li>
 
-                  <li>Any subsequent call to HostResolveImportedModule after FinishDynamicImport has completed, given the arguments _referencingScriptOrModule_, _specifier_, <ins>and _attributes_</ins> must complete normally.</li>
+                  <li>Any subsequent call to HostResolveImportedModule after FinishDynamicImport has completed, given the arguments _referencingScriptOrModule_, and <del>_specifier_</del> <ins>_moduleRequest_</ins> must complete normally.</li>
 
-                  <li>The completion value of any subsequent call to HostResolveImportedModule after FinishDynamicImport has completed, given the arguments _referencingScriptOrModule_, _specifier_, <ins>and _attributes_</ins> must be a module which has already been evaluated, i.e. whose Evaluate concrete method has already been called and returned a normal completion.</li>
+                  <li>The completion value of any subsequent call to HostResolveImportedModule after FinishDynamicImport has completed, given the arguments _referencingScriptOrModule_, and <del>_specifier_,</del> <ins>_moduleRequest_</ins> must be a module which has already been evaluated, i.e. whose Evaluate concrete method has already been called and returned a normal completion.</li>
                 </ul>
               </dd>
 
@@ -149,13 +163,13 @@
 
               <dd>
                 <ul>
-                  <li>At some future time, the host environment must perform FinishDynamicImport(_referencingScriptOrModule_, _specifier_, <ins>_attributes_,</ins> _promiseCapability_, an abrupt completion), with the abrupt completion representing the cause of failure.</li>
+                  <li>At some future time, the host environment must perform FinishDynamicImport(_referencingScriptOrModule_, <del>_specifier_,</del> <ins>_moduleRequest_,</ins> _promiseCapability_, an abrupt completion), with the abrupt completion representing the cause of failure.</li>
                 </ul>
               </dd>
             </dl>
           </li>
           <li>
-            If the host environment takes the success path once for a given _referencingScriptOrModule_, _specifier_<ins>, _attributes_</ins> <del>pair</del><ins>tuple</ins>, it must always do so for subsequent calls.
+            If the host environment takes the success path once for a given _referencingScriptOrModule_, <del>_specifier_,</del> <ins>_moduleRequest_</ins> pair, it must always do so for subsequent calls.
           </li>
           <li>
             The operation must not call _promiseCapability_.[[Resolve]] or _promiseCapability_.[[Reject]], but instead must treat _promiseCapability_ as an opaque identifying value to be passed through to FinishDynamicImport.
@@ -166,15 +180,15 @@
       </emu-clause>
 
       <emu-clause id="sec-finishdynamicimport" aoid="FinishDynamicImport">
-        <h1>Runtime Semantics: FinishDynamicImport ( _referencingScriptOrModule_, _specifier_, <ins>_attributes_,</ins> _promiseCapability_, _completion_ )</h1>
-        <p>The abstract operation FinishDynamicImport takes arguments _referencingScriptOrModule_, _specifier_, <ins>_attributes_,</ins> _promiseCapability_, and _completion_. FinishDynamicImport completes the process of a dynamic import originally started by an <emu-xref href="#sec-import-calls">`import()`</emu-xref> call, resolving or rejecting the promise returned by that call as appropriate according to _completion_. It is performed by host environments as part of HostImportModuleDynamically. It performs the following steps when called:</p>
+        <h1>Runtime Semantics: FinishDynamicImport ( _referencingScriptOrModule_, <del>_specifier_,</del> <ins>_moduleRequest_,</ins> _promiseCapability_, _completion_ )</h1>
+        <p>The abstract operation FinishDynamicImport takes arguments _referencingScriptOrModule_, <del>_specifier_,</del> <ins>_moduleRequest_ (a ModuleRequest Record),</ins> _promiseCapability_, and _completion_. FinishDynamicImport completes the process of a dynamic import originally started by an <emu-xref href="#sec-import-calls">`import()`</emu-xref> call, resolving or rejecting the promise returned by that call as appropriate according to _completion_. It is performed by host environments as part of HostImportModuleDynamically. It performs the following steps when called:</p>
 
 
         <emu-alg>
           1. If _completion_ is an abrupt completion, then perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _completion_.[[Value]] »).
           1. Else,
             1. Assert: _completion_ is a normal completion and _completion_.[[Value]] is *undefined*.
-            1. Let _moduleRecord_ be ! HostResolveImportedModule(_referencingScriptOrModule_, _specifier_<ins>, _attributes_</ins>).
+            1. Let _moduleRecord_ be ! HostResolveImportedModule(_referencingScriptOrModule_, <del>_specifier_,</del> <ins>_moduleRequest_</ins>).
             1. Assert: Evaluate has already been invoked on _moduleRecord_ and successfully completed.
             1. Let _namespace_ be GetModuleNamespace(_moduleRecord_).
             1. If _namespace_ is an abrupt completion, perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _namespace_.[[Value]] »).
@@ -336,10 +350,280 @@
     </emu-alg>
   </emu-clause>
 
+  <emu-clause id="sec-with-clause-early-errors">
+    <h1>Static Semantics: Early Errors</h1>
+    <emu-grammar>WithClause : `with` WithEntries</emu-grammar>
+    <ul>
+      <li>It is a Syntax Error if WithClauseToAttributes of |WithClause| has two entries _a_ and _b_ such that _a_.[[Key]] is _b_.[[Key]].</li>
+    </ul>
+  </emu-clause>
+
+  <emu-clause id="sec-with-clause-to-object" aoid="WithClauseToAttributes">
+    <h1>Runtime Semantics: WithClauseToAttributes</h1>
+    <emu-grammar>WithClause : `with` WithEntries</emu-grammar>
+    <emu-alg>
+      1. Let _attributes_ WithEntriesToAttributes of |WithEntries|.
+      1. Sort _attributes_ by the code point order of the [[Key]] of each entry.  NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among attributes by the order they occur in.
+      1. Return _attributes_.
+    </emu-alg>
+
+    <emu-grammar> WithEntries : IdentifierName `:` StringLiteral </emu-grammar>
+    <emu-alg>
+      1. Let _entry_ be a Record { [[Key]]: StringValue of |IdentifierName|, [[Value]]: StringValue of |StringLiteral|.
+      1. Return a new List containing the single element, _entry_.
+    </emu-alg>
+
+    <emu-grammar> WithEntries : IdentifierName `:` StringLiteral `,` WithEntries </emu-grammar>
+    <emu-alg>
+      1. Let _entry_ be a Record { [[Key]]: StringValue of |IdentifierName|, [[Value]]: StringValue of |StringLiteral|.
+      1. Let _rest_ be WithEntriesToAttributes of |WithEntries|.
+      1. Return a new List containing _entry_ followed by the entries of _rest_.
+    </emu-alg>
+  </emu-clause>
+
+      <emu-clause id="sec-modulerequest-record">
+        <h1>ModuleRequest Records</h1>
+
+        <p>A <dfn>ModuleRequest Record</dfn> represents the request to import a module with given module attributes. It consists of the following fields:</p>
+        <emu-table id="table-cyclic-module-fields" caption="Additional Fields of Cyclic Module Records">
+          <table>
+            <tbody>
+              <tr>
+                <th>
+                  Field Name
+                </th>
+                <th>
+                  Value Type
+                </th>
+                <th>
+                  Meaning
+                </th>
+              </tr>
+              <tr>
+                <td>
+                  [[Specifier]]
+                </td>
+                <td>
+                  String
+                </td>
+                <td>
+                  The module specifier
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  [[Attributes]]
+                </td>
+                <td>
+                  a List of Records { [[Key]]: a String, [[Value]]: a String }
+                </td>
+                <td>
+                  The module attributes
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </emu-table>
+
+        <emu-note type=editor>In general, this proposal replaces places where module specifiers are passed around with ModuleRequest Records. For example, several syntax-directed operations, such as ModuleRequests produce Lists of ModuleRequest Records rather than Lists of Strings which are interpreted as module specifiers. Some algorithms like ImportEntries and ImportEntriesForModule pass around ModuleRequest Records rather than Strings, in a way which doesn't require any particular textual change. Additionally, record fields in Cyclic Module Records and Source Text Module Records which contained Lists of Strings are replaced by Lists of ModuleRequest Records, as indicated above.</emu-note>
+      </emu-clause>
+
+        <emu-table id="table-cyclic-module-fields" caption="Additional Fields of Cyclic Module Records">
+          <table>
+            <tbody>
+              <tr>
+                <th>
+                  Field Name
+                </th>
+                <th>
+                  Value Type
+                </th>
+                <th>
+                  Meaning
+                </th>
+              </tr>
+              <tr>
+                <td>
+                  [[Status]]
+                </td>
+                <td>
+                  ~unlinked~ | ~linking~ | ~linked~ | ~evaluating~ | ~evaluated~
+                </td>
+                <td>
+                  Initially ~unlinked~. Transitions to ~linking~, ~linked~, ~evaluating~, ~evaluated~ (in that order) as the module progresses throughout its lifecycle.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  [[EvaluationError]]
+                </td>
+                <td>
+                  An abrupt completion | *undefined*
+                </td>
+                <td>
+                  A completion of type ~throw~ representing the exception that occurred during evaluation.  *undefined* if no exception occurred or if [[Status]] is not ~evaluated~.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  [[DFSIndex]]
+                </td>
+                <td>
+                  Integer | *undefined*
+                </td>
+                <td>
+                  Auxiliary field used during Link and Evaluate only.
+                  If [[Status]] is ~linking~ or ~evaluating~, this nonnegative number records the point at which the module was first visited during the ongoing depth-first traversal of the dependency graph.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  [[DFSAncestorIndex]]
+                </td>
+                <td>
+                  Integer | *undefined*
+                </td>
+                <td>
+                  Auxiliary field used during Link and Evaluate only. If [[Status]] is ~linking~ or ~evaluating~, this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  [[RequestedModules]]
+                </td>
+                <td>
+                  List of <del>String</del><ins>ModuleRequest Record</ins>
+                </td>
+                <td>
+                  A List of all the |ModuleSpecifier| strings <ins>and module attributes</ins> used by the module represented by this record to request the importation of a module. The List is source code occurrence ordered.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </emu-table>
+      </emu-clause>
+
+        <p>An <dfn id="importentry-record">ImportEntry Record</dfn> is a Record that digests information about a single declarative import. Each ImportEntry Record has the fields defined in <emu-xref href="#table-39"></emu-xref>:</p>
+        <emu-table id="table-39" caption="ImportEntry Record Fields">
+          <table>
+            <tbody>
+            <tr>
+              <th>
+                Field Name
+              </th>
+              <th>
+                Value Type
+              </th>
+              <th>
+                Meaning
+              </th>
+            </tr>
+            <tr>
+              <td>
+                [[ModuleRequest]]
+              </td>
+              <td>
+                <del>String</del>
+                <ins>ModuleRequest Record</ins>
+              </td>
+              <td>
+                <del>String value of the |ModuleSpecifier| of the |ImportDeclaration|.</del>
+                <ins>ModuleRequest Record representing the |ModuleSpecifier| and module attributes of the |ImportDeclaration|.</ins>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[ImportName]]
+              </td>
+              <td>
+                String
+              </td>
+              <td>
+                The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. The value *"\*"* indicates that the import request is for the target module's namespace object.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[LocalName]]
+              </td>
+              <td>
+                String
+              </td>
+              <td>
+                The name that is used to locally access the imported value from within the importing module.
+              </td>
+            </tr>
+            </tbody>
+          </table>
+        </emu-table>
+
+      <emu-clause id="sec-static-semantics-modulerequests">
+        <h1>Static Semantics: ModuleRequests</h1>
+        <emu-see-also-para op="ModuleRequests"></emu-see-also-para>
+        <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
+        <emu-alg>
+          1. <del>Return ModuleRequests of |FromClause|.</del>
+          1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
+          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Attributes]]: an emptyList }.</ins>
+        </emu-alg>
+        <emu-grammar>ImportDeclaration : `import` ImportClause FromClause WithClause `;`</emu-grammar>
+        <emu-alg>
+          1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
+          1. <ins>Let _attributes_ be WithClauseToAttributes of |WithClause|.</ins>
+          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Attributes]]: _attributes_ }.</ins>
+        </emu-alg>
+        <emu-grammar>Module : [empty]</emu-grammar>
+        <emu-alg>
+          1. Return a new empty List.
+        </emu-alg>
+        <emu-grammar>ModuleItemList : ModuleItem</emu-grammar>
+        <emu-alg>
+          1. Return ModuleRequests of |ModuleItem|.
+        </emu-alg>
+        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-alg>
+          1. Let _moduleNames_ be ModuleRequests of |ModuleItemList|.
+          1. Let _additionalNames_ be ModuleRequests of |ModuleItem|.
+          1. Append to _moduleNames_ each element of _additionalNames_ <del>that is not already an element of _moduleNames_</del>.
+          1. Return _moduleNames_.
+        </emu-alg>
+        <emu-note type=editor>Deletion of duplicates is an unnecessary "spec optimization" that would be more complicated to explain in terms of examining module attribute records, and can be simply removed.</emu-note>
+        <emu-grammar>ModuleItem : StatementListItem</emu-grammar>
+        <emu-alg>
+          1. Return a new empty List.
+        </emu-alg>
+        <emu-grammar>
+          ExportDeclaration : `export` ExportFromClause FromClause `;`
+        </emu-grammar>
+        <emu-alg>
+          1. <del>Return ModuleRequests of |FromClause|.</del>
+          1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
+          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Attributes]]: an emptyList }.</ins>
+        </emu-alg>
+        <emu-grammar>
+          ExportDeclaration : `export` ExportFromClause FromClause WithClause `;`
+        </emu-grammar>
+        <emu-alg>
+          1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
+          1. <ins>Let _attributes_ be WithClauseToObject of |WithClause|.</ins>
+          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Attributes]]: _attributes_ }.</ins>
+        </emu-alg>
+        <emu-grammar>
+          ExportDeclaration :
+            `export` NamedExports `;`
+            `export` VariableStatement
+            `export` Declaration
+            `export` `default` HoistableDeclaration
+            `export` `default` ClassDeclaration
+            `export` `default` AssignmentExpression `;`
+        </emu-grammar>
+        <emu-alg>
+          1. Return a new empty List.
+        </emu-alg>
+      </emu-clause>
+
   <h1>TODO</h1>
   <ul>
-    <li>There's a parse-time algorithm which converts WithClause into a List of Attribute Records of the form { [[AttributeKey]]: String, [[AttributeValue]]: String }, and similarly, a runtime algorithm for dynamically created attributes passed through `import()`.</li>
-    <li>RequestedModules becomes a List of Records of the form { [[Specifier]]: String, [[Attributes]]: List of Attribute Records }.</li>
     <li>Update the RequestedModules algorithm to calculate it correctly.</li>
     <li>Update InnerModuleLinking and InnerModuleEvaluation to pass both the specifier and attributes from [[RequestedModules]] records up to HostResolveImportedModule.</li>
     <li>Update most other callsites of HostResolveImportedModule, where the attributes are not so readily available, to search through [[RequestedModules]] to find the attribute value (or, to pass up a don't-care-sentinel).</li>
@@ -355,8 +639,8 @@
 
   <ul>
     <li>The <a href="https://html.spec.whatwg.org/#module-script">module script</a> would have an additional item, which would be the module type, as a string (e.g., *"json"*), or *undefined* for a JavaScript module.</li>
-    <li>HostResolveImportedModule and HostImportModuleDynamically would take an extra _attributes_ parameter, which would be passed down through several abstract operations to reach the <a href="https://html.spec.whatwg.org/#fetch-a-single-module-script">fetch a single module script</a> algorithm. Somewhere near the entrypoint, if _attributes_ is not *undefined*, then let _type_ be ? Get(_attributes_, *"type"*); otherwise let _type_ be *undefined*. If the type is invalid, then an exception is thrown and module loading fails. Otherwise, this will equal the module type, if the module can be successfully fetched with a matching MIME type.</li>
-    <li>In the <a href="https://html.spec.whatwg.org/#fetch-the-descendants-of-a-module-script">fetch the descendents of a module script</a> algorithm, when iterating over [[RequestedModules]], the attribute is saved in parallel with module URLs, and passed on to the internal module script graph fetching procedure (which sends it to "fetch a single module script". Other usage sites of [[RequestedModules]] ignore the attribute.</li>
+    <li>HostResolveImportedModule and HostImportModuleDynamically would take a ModuleRequest Record parameter in place of a specifier string, which would be passed down through several abstract operations to reach the <a href="https://html.spec.whatwg.org/#fetch-a-single-module-script">fetch a single module script</a> algorithm. Somewhere near the entrypoint, if the ModuleRequest Record's [[Attributes]] field has an entry _entry_ such that _entry_.[[Key]] is *"type"*, then let _type_ be _entry_.[[Value]]; otherwise let _type_ be *undefined*. If the type is invalid, then an exception is thrown and module loading fails. Otherwise, this will equal the module type, if the module can be successfully fetched with a matching MIME type.</li>
+    <li>In the <a href="https://html.spec.whatwg.org/#fetch-the-descendants-of-a-module-script">fetch the descendents of a module script</a> algorithm, when iterating over [[RequestedModules]], the elements are ModuleRequest Records rather than just specifier strings; these Records is passed on to the internal module script graph fetching procedure (which sends it to "fetch a single module script". Other usage sites of [[RequestedModules]] ignore the attribute.</li>
     <li>"Fetch a single module script" would check the attribute in two places:
       <ul>
         <li>If the module is found in the module map, then _type_ is checked against he module script's type field. If they differ, then an exception is thrown and module loading fails.</li>


### PR DESCRIPTION
This draft passes around module specifiers + attributes in terms of
ModuleRequest Records. Objects are fully read out eagerly in import().
Any type checks or coercion of attribute values passed to import() is
done by the host. Hosts can also choose whether or not to reject
unknown attributes.